### PR TITLE
fix formatting err

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -193,7 +193,7 @@ func GetFlags() (Flags, error) {
 	}
 
 	// if region is not specified, then apply default region
-	if len(flags.Region) == 0 {
+	if len(flags.Region) == 0 && !flags.All {
 		defaultRegion, err := getDefaultRegion("default")
 		if err != nil {
 			flags.Region = constants.DefaultRegion

--- a/pkg/client/iam.go
+++ b/pkg/client/iam.go
@@ -400,6 +400,10 @@ func (i IAMClient) ScanUser(userGroupMap map[string][]string) ([]resource.Resour
 				return
 			}
 
+			if lastUsed.LastUsedDate == nil {
+				continue
+			}
+
 			if lastlyUsed == nil || lastUsed.LastUsedDate.Sub(*lastlyUsed) > 0 {
 				lastlyUsed = lastUsed.LastUsedDate
 			}

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -106,11 +106,20 @@ func Formatting(i interface{}) interface{} {
 	switch reflect.TypeOf(i).String() {
 	case "*time.Time":
 		if i.(*time.Time) == nil {
-			return constants.EmptyString
+			return "-"
 		}
+		return i.(*time.Time).Format("2006-01-02 15:04:05")
 	case "*string":
 		if i.(*string) == nil {
-			return constants.EmptyString
+			return "-"
+		}
+	case "*int":
+		if i.(*int) == nil {
+			return "-"
+		}
+	case "*int64":
+		if i.(*int64) == nil {
+			return "-"
 		}
 	}
 


### PR DESCRIPTION
#5 #6 

Fix formatting error 
- nil value (include empty string) will be presented with `-`
- Time value will be formatted like `"2006-01-02 15:04:05"` 

Plus
--all option gets conflict with region configuration right now. This error occurred because I put default region of shell to `flags.Region`. 
Fix this issue as well